### PR TITLE
Acctupdate

### DIFF
--- a/app/assets/stylesheets/devise_views.scss
+++ b/app/assets/stylesheets/devise_views.scss
@@ -100,6 +100,9 @@ $neutral: #EFEFEF;
 // Edit Account Page
 
 form#edit_user {
+  div {
+    margin-top: .5em;
+  }
   .actions {
     margin-top: 2em;
   }

--- a/app/assets/stylesheets/devise_views.scss
+++ b/app/assets/stylesheets/devise_views.scss
@@ -66,7 +66,6 @@ $neutral: #EFEFEF;
     margin-bottom: 30px;
   }
 }
-
 .login-with {
   width: 50%;
   display: block;
@@ -82,7 +81,6 @@ $neutral: #EFEFEF;
 .display-inline-flex{
   display: flex;
 }
-
 .devise-box input[type=checkbox]{
   width: 17px;
   padding-top: 0px;
@@ -97,6 +95,14 @@ $neutral: #EFEFEF;
 
 .signup-location {
   overflow: hidden;
+}
+
+// Edit Account Page
+
+form#edit_user {
+  .actions {
+    margin-top: 2em;
+  }
 }
 
 #city-field > input {

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,32 @@
+module Users
+
+  class RegistrationsController < Devise::RegistrationsController
+    def update
+      account_update_params = devise_parameter_sanitizer.sanitize(:account_update)
+      @user = User.find(current_user.id)
+
+      if needs_password?
+        successfully_updated = @user.update_with_password(account_update_params)
+      else
+        account_update_params.delete('password')
+        account_update_params.delete('password_confirmation')
+        account_update_params.delete('current_password')
+        successfully_updated = @user.update_attributes(account_update_params)
+      end
+
+      if successfully_updated
+        set_flash_message :notice, :updated
+        sign_in @user, :bypass => true
+        redirect_to user_path(current_user)
+      else
+        render 'edit'
+      end
+    end
+
+    private
+
+    def needs_password?
+      @user.email != params[:user][:email] || params[:user][:password].present?
+    end
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -24,15 +24,18 @@
     <div class="field state_selector">
       <%= f.label :state %>
       <%= f.select(:state, options_for_select([["Select", ""], ["AL", "AL"], ["AK", "AK"], ["AZ", "AZ"], ["AR", "AR"], ["CA", "CA"], ["CO", "CO"], ["CT", "CT"], ["DE", "DE"], ["FL", "FL"],  ["GA", "GA"], ["HI", "HI"], ["ID", "ID"], ["IL", "IL"], ["IN", "IN"], ["IA", "IA"], ["KS", "KS"], ["KY", "KY"], ["LA", "LA"], ["ME", "ME"], ["MD", "MD"], ["MA", "MA"], ["MI", "MI"], ["MN", "MN"], ["MS", "MS"], ["MO", "MO"], ["MT", "MT"], ["NE", "NE"], ["NV", "NV"], ["NH", "NH"], ["NJ", "NJ"], ["NM", "NM"], ["NY", "NY"], ["NC", "NC"], ["ND", "ND"], ["OH", "OH"], ["OK", "OK"], ["OR", "OR"], ["PA", "PA"], ["RI", "RI"], ["SC", "SC"], ["SD", "SD"], ["TN", "TN"], ["TX", "TX"], ["UT", "UT"], ["VT", "VT"], ["VA", "VA"], ["WA", "WA"], ["WV", "WV"], ["WI", "WI"], ["WY", "WY"]
-      ], selected: f.object.state)) %> <br>
+      ], selected: f.object.state)) %>
     </div>
   </div>
+
+
+  <% if !(["facebook", "twitter"].include?(current_user.provider)) %>
 
   <div class="field">
     <%= f.label :email %>
     <%= f.email_field :email, autofocus: true %>
     <div class="display-error"><%= display_error_user(:email) %></div>
-  </div><br>
+  </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
@@ -43,7 +46,6 @@
     <%= f.password_field :password, autocomplete: "off" %>
     <div class="display-error"><%= display_error_user(:password) %></div>
     <% if @minimum_password_length %>
-      <br />
       <em><%= @minimum_password_length %> characters minimum</em>
     <% end %>
   </div>
@@ -51,20 +53,18 @@
   <div class="field">
     <%= f.label :password_confirmation %>
     <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div><br>
+  </div>
 
 
   <div class="field">
     <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
     <%= f.password_field :current_password, autocomplete: "off" %>
-  </div><br>
+  </div>
 
-  <!-- <div class="field">
-    <%= f.label :role %>
-    <%= select_tag(:role, options_for_select([['Volunteer', 1], ['Organizer', 2]], 1)) %>
-  </div> -->
+  <% end %>
+
   <div class="field">
-    <% f.label :image %>
+    <label>Profile picture</label>
     <%= f.file_field :image %>
   </div>
 
@@ -73,6 +73,4 @@
   </div>
 <% end %>
 
-<br>
-<br>
 <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-sm btn-danger" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   get 'about' => 'landing_page#about'
 
-  devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
+  devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks", :registrations => "users/registrations" }
   resources :users do
     get :get_events
     get 'user_map_locations'


### PR DESCRIPTION
Change devise so only email & password updates require current password. Facebook & Twitter users will not see email or password update fields on the edit page. Add label for profile picture field. Some general styling.